### PR TITLE
Expose grpc server port to outside of K8 cluster

### DIFF
--- a/deployments/deploy.yaml
+++ b/deployments/deploy.yaml
@@ -21,6 +21,12 @@ spec:
     port: 2112
     targetPort: 2112
     nodePort: 30017
+  # TODO: for testing purposes only; remove once product is more mature
+  - name: grpc
+    protocol: TCP
+    port: 5000
+    targetPort: 5000
+    nodePort: 30018
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
This change is for exposing the grpc server to make local testing easier. For example, we can run a diago worker outside of the K8 cluster if we want to now. This change should be reverted later on before we productionalize the product as it could be a security issue.

