### PR TITLE
Feat/non k8s leader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	# kubectl get po
 
 docker:
-	docker build --no-cache -f build/package/Dockerfile -t diago .
+	eval $(minikube docker-env) && docker build -f build/package/Dockerfile -t diago .
 
 remove:
 	- kubectl delete sts diago
@@ -16,6 +16,8 @@ remove:
 run:
 	kubectl apply -f deployments/deploy.yaml
 	kubectl get po
+
+do: build docker remove run
 
 logs:
 	kubectl logs diago-0 -f

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,8 +8,6 @@ import (
 	"github.com/t-bfame/diago/cmd/server"
 	"github.com/t-bfame/diago/internal/scheduler"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 )
@@ -17,13 +15,6 @@ import (
 func main() {
 	s := scheduler.NewScheduler()
 	var opts []grpc.ServerOption
-
-	g := promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "diago_alive",
-		Help: "Currently supported capacity",
-	})
-
-	g.Set(1)
 
 	go func() {
 		apiServer := server.NewApiServer(&s)

--- a/cmd/server/grpc.go
+++ b/cmd/server/grpc.go
@@ -37,11 +37,13 @@ func (s *workerServer) Coordinate(stream pb.Worker_CoordinateServer) error {
 
 	reg := msg.GetRegister()
 	group := reg.GetGroup()
+	freq := reg.GetFrequency()
+
 	instance := scheduler.InstanceID(reg.GetInstance())
 
-	log.WithField("group", group).WithField("instance", instance).Info("Received registration for pod")
+	log.WithField("group", group).WithField("instance", instance).WithField("frequency", freq).Info("Received registration for pod")
 
-	leaderMsgs, workerMsgs, err := s.sched.Register(group, instance)
+	leaderMsgs, workerMsgs, err := s.sched.Register(group, instance, freq)
 
 	if err != nil {
 		log.WithError(err).Error("Encountered error during registeration")

--- a/deployments/rbac.yaml
+++ b/deployments/rbac.yaml
@@ -6,28 +6,28 @@ metadata:
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
-  verbs: ["get", "watch", "list"]
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: Role
-# metadata:
-#   namespace: default
-#   name: pod-manager
-# rules:
-# - apiGroups: [""]
-#   resources: ["pods"]
-#   verbs: ["get", "watch", "list", "create", "delete"]
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: RoleBinding
-# metadata:
-#   name: blah
-#   namespace: default
-# subjects:
-# - kind: ServiceAccount
-#   name: default
-#   namespace: default
-# roleRef:
-#   kind: Role
-#   name: pod-manager
-#   apiGroup: "rbac.authorization.k8s.io"
+  verbs: ["get", "watch", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-manager
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: blah
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+roleRef:
+  kind: Role
+  name: pod-manager
+  apiGroup: "rbac.authorization.k8s.io"

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -267,6 +268,7 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
+github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
@@ -330,6 +332,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/internal/metrics/aggregator.go
+++ b/internal/metrics/aggregator.go
@@ -225,6 +225,7 @@ func (e *tdigestEstimator) Get(q float64) float64 {
 	return e.TDigest.Quantile(q)
 }
 
+// NewMetricAggregator Creates a new MAgg
 func NewMetricAggregator(testid string, instanceid string, jobid string) *Metrics {
 	var magg Metrics
 

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -53,6 +53,14 @@ func (pc *LoadTestCollection) clear() {
 	pc.bytesOut.Set(0)
 	pc.requests.Set(0)
 	pc.success.Set(0)
+
+	prometheus.Unregister(pc.latencyMean)
+	prometheus.Unregister(pc.latencyMin)
+	prometheus.Unregister(pc.latencyMax)
+	prometheus.Unregister(pc.bytesIn)
+	prometheus.Unregister(pc.bytesOut)
+	prometheus.Unregister(pc.requests)
+	prometheus.Unregister(pc.success)
 }
 
 // NewLoadTestCollection returns a new prometheus metric collection

--- a/internal/scheduler/capacitymgr.go
+++ b/internal/scheduler/capacitymgr.go
@@ -124,7 +124,7 @@ func (cm *CapacityManager) removeInstance(instance InstanceID) {
 	cm.pdcol.updateCurrentCapacity(cm.nonBlockingCurrentCapacity())
 }
 
-func (cm *CapacityManager) addInstance(instance InstanceID) error {
+func (cm *CapacityManager) addInstance(instance InstanceID, frequency uint64) error {
 	cm.capmux.Lock()
 	defer cm.capmux.Unlock()
 

--- a/internal/scheduler/podgrp.go
+++ b/internal/scheduler/podgrp.go
@@ -130,7 +130,7 @@ func (pg *PodGroup) removeJob(id m.JobID) (err error) {
 	return nil
 }
 
-func (pg *PodGroup) registerPod(group string, instance InstanceID) (leader chan Incoming, worker chan Outgoing, err error) {
+func (pg *PodGroup) registerPod(group string, instance InstanceID, frequency uint64) (leader chan Incoming, worker chan Outgoing, err error) {
 	pg.qmux.Lock()
 	defer pg.qmux.Unlock()
 
@@ -138,7 +138,7 @@ func (pg *PodGroup) registerPod(group string, instance InstanceID) (leader chan 
 	worker = make(chan Outgoing, 2) // messages for worker
 
 	pg.scheduledPods[instance] = worker
-	pg.capmgr.addInstance(instance)
+	pg.capmgr.addInstance(instance, frequency)
 
 	// Mux events from pod to correct job channels
 	go func() {

--- a/internal/scheduler/podmgr.go
+++ b/internal/scheduler/podmgr.go
@@ -23,7 +23,7 @@ func (pm PodManager) createPodGroup(groupName string) (pg *PodGroup) {
 	return pm.podGroups[groupName]
 }
 
-func (pm PodManager) register(group string, instance InstanceID) (leader chan Incoming, worker chan Outgoing, err error) {
+func (pm PodManager) register(group string, instance InstanceID, frequency uint64) (leader chan Incoming, worker chan Outgoing, err error) {
 	pg, ok := pm.podGroups[group]
 
 	// In this case, leader was not responsible for spinning up the worker process
@@ -34,7 +34,7 @@ func (pm PodManager) register(group string, instance InstanceID) (leader chan In
 	}
 
 	// Add test channel for multiplexing
-	return pg.registerPod(group, instance)
+	return pg.registerPod(group, instance, frequency)
 }
 
 func (pm PodManager) schedule(j m.Job, events chan Event) (err error) {

--- a/internal/scheduler/podmgr.go
+++ b/internal/scheduler/podmgr.go
@@ -7,6 +7,8 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // PodManager Manages pods created by diago in K8s cluster
@@ -15,11 +17,20 @@ type PodManager struct {
 	podGroups map[string]*PodGroup
 }
 
+func (pm PodManager) createPodGroup(groupName string) (pg *PodGroup) {
+	pm.podGroups[groupName] = NewPodGroup(groupName, pm.clientset)
+
+	return pm.podGroups[groupName]
+}
+
 func (pm PodManager) register(group string, instance InstanceID) (leader chan Incoming, worker chan Outgoing, err error) {
 	pg, ok := pm.podGroups[group]
 
+	// In this case, leader was not responsible for spinning up the worker process
+	// and it will simply create initialize a new group to accomodate discovery
 	if !ok {
-		return nil, nil, errors.New("Could not find specified group")
+		log.WithField("group", group).Debug("Group doesnt exist, creating a new group during registration")
+		pg = pm.createPodGroup(group)
 	}
 
 	// Add test channel for multiplexing
@@ -27,12 +38,12 @@ func (pm PodManager) register(group string, instance InstanceID) (leader chan In
 }
 
 func (pm PodManager) schedule(j m.Job, events chan Event) (err error) {
-	groupName := j.Group
-	pg, ok := pm.podGroups[groupName]
+	group := j.Group
+	pg, ok := pm.podGroups[group]
 
 	if !ok {
-		pg = NewPodGroup(groupName, pm.clientset)
-		pm.podGroups[groupName] = pg
+		log.WithField("group", group).Debug("Group doesnt exist, creating a new group")
+		pg = pm.createPodGroup(group)
 	}
 
 	// Add channel for receiving events

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -25,8 +25,8 @@ func (s Scheduler) Stop(j m.Job) (err error) {
 }
 
 // Register something
-func (s Scheduler) Register(group string, instance InstanceID) (chan Incoming, chan Outgoing, error) {
-	return s.pm.register(group, instance)
+func (s Scheduler) Register(group string, instance InstanceID, frequency uint64) (chan Incoming, chan Outgoing, error) {
+	return s.pm.register(group, instance, frequency)
 }
 
 // NewScheduler laalala

--- a/test.sh
+++ b/test.sh
@@ -93,7 +93,7 @@ get_instance() {
 
 testid=""
 pad
-make_dummy_test
+make_dummy_test2
 
 # strip quotes from id
 testid=$(echo $testid | tr -d '"')

--- a/test.sh
+++ b/test.sh
@@ -102,9 +102,9 @@ pad
 
 get_test
 submit_test
-get_instance
+# get_instance
 
-# sleep 5
+sleep 30
 
 # stop_test
 get_instance


### PR DESCRIPTION
This PR:
- Adds the RBAC configs required for the leader to create pods
- Removes prometheus metrics that are hanging around from previous tests
- Ability to initialise pod manager on registration call from worker, allowing local workers
- Pass frequency to the capacity manager for further use during job assignment (cc @brity)