### PR TITLE
fix: storage integration + scheduler PR fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ do: local remove deploy
 logs:
 	kubectl logs diago-0 -f --namespace=diago
 
+watch:
+	kubectl get po -n diago -w
+
 PROTOC := protoc
 
 .PHONY: proto
@@ -39,6 +42,9 @@ crd-gen:
 
 test:
 	go test -v -coverprofile=coverage.out ./...
+
+create-flow:
+	./test/create.sh
 
 flow:
 	./test/test.sh

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	config.Init()
-	storage.InitDatabase(storage.DatabaseName)
+	storage.InitDatabase(config.Diago.StoragePath)
 
 	if config.Diago.Debug {
 		log.SetLevel(log.DebugLevel)

--- a/cmd/server/apiserver.go
+++ b/cmd/server/apiserver.go
@@ -14,7 +14,6 @@ import (
 	m "github.com/t-bfame/diago/internal/model"
 	sch "github.com/t-bfame/diago/internal/scheduler"
 	sto "github.com/t-bfame/diago/internal/storage"
-	"github.com/t-bfame/diago/pkg/utils"
 )
 
 // APIServer serves API calls over HTTP
@@ -88,7 +87,7 @@ func (server *APIServer) Start() {
 
 		// For now, make id by using random hash of length 5
 		// TODO: Maybe use a counter for every group for better UX?
-		testid := fmt.Sprintf("%s-%s", test.Name, utils.RandHash(5))
+		testid := test.Name
 		test.ID = m.TestID(testid)
 
 		for i := range test.Jobs {

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	DefaultGroupCapacity uint64 `envconfig:"DIAGO_DEFAULT_GROUP_CAPACITY" default:"20"`
 	DefaultNamespace     string `envconfig:"DIAGO_DEFAULT_NAMESPACE" default:"default"`
 
+	StoragePath string `envconfig:"DIAGO_STORAGE_PATH" default:"diago.db"`
+
 	Debug bool `envconfig:"DIAGO_DEBUG" default:"false"`
 }
 

--- a/internal/scheduler/model.go
+++ b/internal/scheduler/model.go
@@ -47,11 +47,12 @@ func (sm SchedulerModel) getEnvs(group string, instance InstanceID) map[string]s
 	}
 
 	envs := map[string]string{
-		"DIAGO_WORKER_GROUP":                group,
-		"DIAGO_WORKER_GROUP_INSTANCE":       string(instance),
-		"DIAGO_LEADER_HOST":                 c.Diago.Host,
-		"DIAGO_LEADER_PORT":                 fmt.Sprintf("%d", c.Diago.GRPCPort),
-		"ALLOWED_INACTIVITY_PERIOD_SECONDS": fmt.Sprintf("%d", workerConfig.Spec.AllowedInactivityPeriod),
+		"DIAGO_WORKER_GROUP":                   group,
+		"DIAGO_WORKER_GROUP_INSTANCE":          string(instance),
+		"DIAGO_LEADER_HOST":                    c.Diago.Host,
+		"DIAGO_LEADER_PORT":                    fmt.Sprintf("%d", c.Diago.GRPCPort),
+		"ALLOWED_INACTIVITY_PERIOD_SECONDS":    fmt.Sprintf("%d", workerConfig.Spec.AllowedInactivityPeriod),
+		"DIAGO_WORKER_GROUP_INSTANCE_CAPACITY": fmt.Sprintf("%d", workerConfig.Spec.Capacity),
 	}
 
 	return envs

--- a/internal/storage/common.go
+++ b/internal/storage/common.go
@@ -6,10 +6,6 @@ import (
 	"github.com/boltdb/bolt"
 )
 
-const (
-	DatabaseName = "my.db"
-)
-
 var (
 	db *bolt.DB
 )

--- a/manifests/leader/diago-clusterrolebinding.yaml
+++ b/manifests/leader/diago-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: diago-role-binding
 subjects:
 - kind: ServiceAccount
-  name: diago
+  name: diago-sa
   namespace: diago
 roleRef:
   kind: Role

--- a/manifests/leader/diago-pvc.yaml
+++ b/manifests/leader/diago-pvc.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: diago-pvc
+  labels:
+    app.kubernetes.io/name: diago
+    app.kubernetes.io/part-of: diago
+    app.kubernetes.io/component: leader
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/manifests/leader/diago-sa.yaml
+++ b/manifests/leader/diago-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: diago
+    app.kubernetes.io/part-of: diago
+    app.kubernetes.io/component: leader
+  name: diago-sa

--- a/manifests/leader/diago-sts.yaml
+++ b/manifests/leader/diago-sts.yaml
@@ -19,17 +19,26 @@ spec:
         app.kubernetes.io/part-of: diago
         app.kubernetes.io/component: leader
     spec:
-      serviceAccountName: diago
+      serviceAccountName: diago-sa
       containers:
       - name: leader
         image: diago
         imagePullPolicy: Never
+        volumeMounts:
+        - name: diago-storage
+          mountPath: "/storage"
         env:
         - name: "DIAGO_HOST"
           valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        - name: "DIAGO_STORAGE_PATH"
+          value: "/storage/diago.db"
         envFrom:
         - configMapRef:
             name: diago-cm
+      volumes:
+        - name: diago-storage
+          persistentVolumeClaim:
+            claimName: diago-pvc
       terminationGracePeriodSeconds: 0

--- a/manifests/leader/kustomization.yaml
+++ b/manifests/leader/kustomization.yaml
@@ -3,8 +3,10 @@ kind: Kustomization
 
 resources:
 - diago-ns.yaml
+- diago-sa.yaml
 - diago-clusterrole.yaml
 - diago-clusterrolebinding.yaml
 - diago-cm.yaml
 - diago-svc.yaml
+- diago-pvc.yaml
 - diago-sts.yaml

--- a/test/create.sh
+++ b/test/create.sh
@@ -1,0 +1,59 @@
+base=$(minikube ip)
+
+pad() {
+  printf "\n\n\n"
+}
+
+make_dummy_test() {
+  output=$(curl "$base:30007/tests"\
+        -H "Content-Type: application/json"\
+        -d "{
+            \"Name\": \"Test1\",
+            \"Jobs\": [
+              {
+                \"Name\": \"alpha\",
+                \"Group\": \"test-worker\",
+                \"Priority\": 0,
+                \"Frequency\":  5,
+			          \"Duration\":   30,
+			          \"HTTPMethod\": \"GET\",
+			          \"HTTPUrl\":    \"https://www.google.com\"
+              },
+              {
+                \"Name\": \"beta\",
+                \"Group\": \"test-worker\",
+                \"Priority\": 0,
+                \"Frequency\":  5,
+			          \"Duration\":   30,
+			          \"HTTPMethod\": \"GET\",
+			          \"HTTPUrl\":    \"https://www.google.com\"
+              }
+            ]
+          }")
+  testid=$(echo $output | python3 -c "import sys, json; print(json.load(sys.stdin)['payload']['testid'])")
+}
+
+make_dummy_test2() {
+  output=$(curl "$base:30007/tests"\
+        -H "Content-Type: application/json"\
+        -d "{
+            \"Name\": \"Test2\",
+            \"Jobs\": [
+              {
+                \"Name\": \"alpha\",
+                \"Group\": \"test-worker\",
+                \"Priority\": 0,
+                \"Frequency\":  5,
+			          \"Duration\":   30,
+			          \"HTTPMethod\": \"GET\",
+			          \"HTTPUrl\":    \"https://www.google.com\"
+              }
+            ]
+          }")
+  testid=$(echo $output | python3 -c "import sys, json; print(json.load(sys.stdin)['payload']['testid'])")
+}
+
+kubectl apply -f test/test.yaml
+
+make_dummy_test
+make_dummy_test2

--- a/test/test.sh
+++ b/test/test.sh
@@ -4,55 +4,6 @@ pad() {
   printf "\n\n\n"
 }
 
-make_dummy_test() {
-  output=$(curl "$base:30007/tests"\
-        -H "Content-Type: application/json"\
-        -d "{
-            \"Name\": \"Test1\",
-            \"Jobs\": [
-              {
-                \"Name\": \"alpha\",
-                \"Group\": \"test-worker\",
-                \"Priority\": 0,
-                \"Frequency\":  5,
-			          \"Duration\":   30,
-			          \"HTTPMethod\": \"GET\",
-			          \"HTTPUrl\":    \"https://www.google.com\"
-              },
-              {
-                \"Name\": \"beta\",
-                \"Group\": \"test-worker\",
-                \"Priority\": 0,
-                \"Frequency\":  5,
-			          \"Duration\":   30,
-			          \"HTTPMethod\": \"GET\",
-			          \"HTTPUrl\":    \"https://www.google.com\"
-              }
-            ]
-          }")
-  testid=$(echo $output | python3 -c "import sys, json; print(json.load(sys.stdin)['payload']['testid'])")
-}
-
-make_dummy_test2() {
-  output=$(curl "$base:30007/tests"\
-        -H "Content-Type: application/json"\
-        -d "{
-            \"Name\": \"Test1\",
-            \"Jobs\": [
-              {
-                \"Name\": \"alpha\",
-                \"Group\": \"test-worker\",
-                \"Priority\": 0,
-                \"Frequency\":  5,
-			          \"Duration\":   30,
-			          \"HTTPMethod\": \"GET\",
-			          \"HTTPUrl\":    \"https://www.google.com\"
-              }
-            ]
-          }")
-  testid=$(echo $output | python3 -c "import sys, json; print(json.load(sys.stdin)['payload']['testid'])")
-}
-
 get_test() {
   curl "$base:30007/tests/$testid" | python3 -m json.tool
   pad
@@ -90,22 +41,15 @@ get_instance() {
 
 # sleep 5
 
-kubectl apply -f test/test.yaml
+testid="Test2"
 
-testid=""
-pad
-make_dummy_test2
-
-# strip quotes from id
-testid=$(echo $testid | tr -d '"')
-echo "created test with id: $testid"
+echo "starting test with id: $testid"
 pad
 
 get_test
 submit_test
-# get_instance
 
-sleep 10
+sleep 30
 
 # stop_test
 get_instance

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -2,6 +2,7 @@ apiVersion: diago.app/v1alpha1
 kind: WorkerGroup
 metadata:
   name: test-worker
+  namespace: diago
 spec:
   image: diago-worker
   capacity: 20


### PR DESCRIPTION
This PR:

- Moves storage path config to config/config.go
- Adds service account and PVC K8s configs allowing diago to store data into Volumes
- Removes random hash creation from test instance name
- Adds missing capacity specitification during pod creation
- Uses separate scripts for test creation and runs for better testing

I also tested diago by:
- spinning up a new instance of diago
- creating 2 new tests by running `/test/create.sh`
- running the created tests by running `/test/test.sh`
- killing the diago pod manually by running `kubectl delete po diago-0 -n diago`
- Waiting for replacement pod to be spun up
- running created tests again (without actually creating the tests)

Above validates that the tests were created and stored in the storage layer successfully. We can access stored tests and test results across pod restarts which is good for reliability.