### PR TITLE
TestScheduling v1

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/t-bfame/diago/cmd/server"
 	"github.com/t-bfame/diago/config"
+	"github.com/t-bfame/diago/internal/manager"
 	"github.com/t-bfame/diago/internal/scheduler"
 	"github.com/t-bfame/diago/internal/storage"
 
@@ -29,9 +30,12 @@ func main() {
 	router := mux.NewRouter()
 
 	go func() {
+		jf := manager.NewJobFunnel(s)
+		sm := manager.NewScheduleManager(jf)
+
 		// Set prefix for api paths
 		apiRouter := router.PathPrefix("/api").Subrouter()
-		apiServer := server.NewAPIServer(s)
+		apiServer := server.NewAPIServer(s, jf, sm)
 		apiServer.Start(apiRouter)
 
 		server.NewUIBox(router)

--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,15 @@ require (
 	github.com/karrick/godirwalk v1.16.1 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.9.0
-	github.com/rogpeppe/go-internal v1.6.2 // indirect
+	github.com/robfig/cron/v3 v3.0.0
+	github.com/rogpeppe/go-internal v1.7.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
-	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
-	golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 // indirect
+	golang.org/x/tools v0.1.0 // indirect
 	google.golang.org/grpc v1.34.1
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -381,12 +381,16 @@ github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULU
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.5.2 h1:qLvObTrvO/XRCqmkKxUlOBc48bI3efyDuAZe25QiF0w=
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.7.0 h1:3qqXGV8nn7GJT65debw77Dzrx9sfWYgP0DDo7xcMFRk=
+github.com/rogpeppe/go-internal v1.7.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
@@ -572,6 +576,8 @@ golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
 golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
@@ -619,6 +625,8 @@ golang.org/x/tools v0.0.0-20200308013534-11ec41452d41 h1:9Di9iYgOt9ThCipBxChBVhg
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 h1:BTs2GMGSMWpgtCpv1CE7vkJTv7XcHdcLLnAMu7UbgTY=
 golang.org/x/tools v0.0.0-20210115202250-e0d201561e39/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/manager/jobfunnel.go
+++ b/internal/manager/jobfunnel.go
@@ -39,14 +39,14 @@ func (jf *JobFunnel) endOp(key string) {
 
 // BeginTest creates a TestInstance for the Test with the specified TestID
 // if another instance of the same Test is not already ongoing
-func (jf *JobFunnel) BeginTest(testID m.TestID) error {
+func (jf *JobFunnel) BeginTest(testID m.TestID, testType string) error {
 	key := string(testID)
 	jf.startOp(key)
 	defer jf.endOp(key)
 
 	test, err := sto.GetTestByTestId(m.TestID(key))
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot find Test<%s>", key)
 	}
 
 	if jf.ongoing[key] {
@@ -59,7 +59,7 @@ func (jf *JobFunnel) BeginTest(testID m.TestID) error {
 	instance := &m.TestInstance{
 		ID:        m.TestInstanceID(instanceid),
 		TestID:    m.TestID(testID),
-		Type:      "adhoc",
+		Type:      testType,
 		Status:    "submitted",
 		CreatedAt: now,
 	}
@@ -176,7 +176,7 @@ func (jf *JobFunnel) StopTest(testID m.TestID) error {
 
 	test, err := sto.GetTestByTestId(m.TestID(key))
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot find Test<%s>", key)
 	}
 
 	if !jf.ongoing[key] {

--- a/internal/manager/schedulemgr.go
+++ b/internal/manager/schedulemgr.go
@@ -1,0 +1,100 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/robfig/cron/v3"
+	log "github.com/sirupsen/logrus"
+
+	m "github.com/t-bfame/diago/internal/model"
+)
+
+type ScheduleManager struct {
+	specParser cron.Parser
+	entries    map[m.TestScheduleID]cron.EntryID
+	cronRunner *cron.Cron
+	jf         *JobFunnel
+}
+
+func (sm *ScheduleManager) Add(schedule *m.TestSchedule) error {
+	// TODO: add to storage
+
+	entryID, err := sm.cronRunner.AddFunc(schedule.CronSpec, func() {
+		log.WithField("TestScheduleID", schedule.ID).
+			Info("About to start scheduled test")
+		err := sm.jf.BeginTest(
+			schedule.TestID,
+			"scheduled",
+		)
+		if err != nil {
+			log.WithField("TestScheduleID", schedule.ID).
+				WithError(err).
+				Errorf("Scheduled test failed to start")
+		}
+	})
+
+	if err != nil {
+		return err
+	}
+
+	sm.entries[schedule.ID] = entryID
+	log.WithField("TestScheduleID", schedule.ID).
+		Info("Added TestSchedule")
+
+	return nil
+}
+
+func (sm *ScheduleManager) Remove(id m.TestScheduleID) error {
+	entryID, exists := sm.entries[id]
+	if !exists {
+		return fmt.Errorf("TestSchedule<%s> is not currently running", id)
+	}
+
+	sm.cronRunner.Remove(entryID)
+	delete(sm.entries, id)
+
+	log.WithField("TestScheduleID", id).
+		Info("Removed TestSchedule")
+
+	// TODO: delete from storage
+
+	return nil
+}
+
+func (sm *ScheduleManager) Update(schedule *m.TestSchedule) error {
+	err := sm.Remove(schedule.ID)
+	if err != nil {
+		return err
+	}
+	err = sm.Add(schedule)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sm *ScheduleManager) ValidateSpec(spec string) error {
+	_, err := sm.specParser.Parse(spec)
+	return err
+}
+
+func (sm *ScheduleManager) onStart() {
+	// TODO: query storage for all TestSchedules and run all
+	sm.cronRunner.Start()
+	log.Info("ScheduleManager started cron runner")
+}
+
+func NewScheduleManager(jf *JobFunnel) *ScheduleManager {
+	sm := &ScheduleManager{
+		// standardParser according to https://github.com/robfig/cron/blob/v3.0.1/parser.go#L217
+		cron.NewParser(
+			cron.Minute | cron.Hour | cron.Dom | cron.Month |
+				cron.Dow | cron.Descriptor,
+		),
+		map[m.TestScheduleID]cron.EntryID{},
+		cron.New(),
+		jf,
+	}
+	sm.onStart()
+	return sm
+}

--- a/internal/model/testschedule.go
+++ b/internal/model/testschedule.go
@@ -1,0 +1,10 @@
+package model
+
+type TestScheduleID string
+
+type TestSchedule struct {
+	ID       TestScheduleID
+	Name     string `validation:"required"`
+	TestID   TestID `validation:"required"`
+	CronSpec string `validation:"required"`
+}

--- a/internal/storage/test.go
+++ b/internal/storage/test.go
@@ -51,6 +51,7 @@ func GetTestByTestId(testId model.TestID) (*model.Test, error) {
 		return nil
 	}); err != nil {
 		log.WithError(err).WithField("TestId", testId).Error("Failed to GetTestByTestId")
+		return nil, err
 	}
 	return result, nil
 }


### PR DESCRIPTION
Added `/api/test-schedules` for creating, getting, updating, and deleting test schedules.
Added `ScheduleManager` to start/stop cron jobs that enforce TestSchedules.

Tested with the following:
```
# create
curl "$(minikube ip):30007/api/test-schedules"\ 
  -H "Content-Type: application/json"\
  -d "{
      \"Name\": \"TestSchedule1\",
      \"TestID\": \"Test2\",
      \"CronSpec\": \"* * * * *\",
      }" | python3 -m json.tool

# delete
curl -X DELETE "$(minikube ip):30007/api/test-schedules/TestSchedule1" | python3 -m json.tool

# update
curl "$(minikube ip):30007/api/test-schedules/TestSchedule1"\ 
  -X "PUT"\
  -H "Content-Type: application/json"\
  -d "{
      \"Name\": \"TestSchedule1\",
      \"TestID\": \"Test2\",
      \"CronSpec\": \"2 * * * *\",
      }" | python3 -m json.tool
```