### PR TITLE
TestSchedules: storage Integration & schedule on start

### DIFF
--- a/internal/manager/jobfunnel.go
+++ b/internal/manager/jobfunnel.go
@@ -47,8 +47,8 @@ func (jf *JobFunnel) BeginTest(testID m.TestID, testType string) error {
 	defer jf.endOp(key)
 
 	test, err := sto.GetTestByTestId(m.TestID(key))
-	if err != nil {
-		return fmt.Errorf("Cannot find Test<%s>", key)
+	if err != nil || test == nil {
+		return fmt.Errorf("Cannot retrieve Test<%s>", key)
 	}
 
 	if jf.ongoing[key] {
@@ -200,8 +200,8 @@ func (jf *JobFunnel) StopTest(testID m.TestID) error {
 	defer jf.endOp(key)
 
 	test, err := sto.GetTestByTestId(m.TestID(key))
-	if err != nil {
-		return fmt.Errorf("Cannot find Test<%s>", key)
+	if err != nil || test == nil {
+		return fmt.Errorf("Cannot retrieve Test<%s>", key)
 	}
 
 	if !jf.ongoing[key] {

--- a/test/schedule.sh
+++ b/test/schedule.sh
@@ -1,0 +1,13 @@
+base=$(minikube ip)
+
+schedule_test1() {
+  curl "$base:30007/api/test-schedules"\
+    -H "Content-Type: application/json"\
+    -d "{
+        \"Name\": \"TestSchedule1\",
+        \"TestID\": \"Test1\",
+        \"CronSpec\": \"* * * * *\"
+      }"
+}
+
+schedule_test1


### PR DESCRIPTION
- Integrate scheduled tests with storage. Query storage to reschedule cron jobs on leader start.
- Allow for deletion of tests and test schedules.