### PR TITLE
feat: Chaos Manager API Integration

### DIFF
--- a/cmd/server/apiserver.go
+++ b/cmd/server/apiserver.go
@@ -94,6 +94,10 @@ func (server *APIServer) Start(router *mux.Router) {
 			test.Jobs[i].ID = m.JobID(fmt.Sprintf("%s-%d", test.ID, i))
 		}
 
+		for i := range test.Chaos {
+			test.Chaos[i].ID = m.ChaosID(fmt.Sprintf("%s-%d", test.ID, i))
+		}
+
 		err = sto.AddTest(&test)
 		if err != nil {
 			w.Write(buildFailure(err.Error(), http.StatusInternalServerError, w))

--- a/internal/model/chaos.go
+++ b/internal/model/chaos.go
@@ -1,9 +1,24 @@
 package model
 
+type ChaosID string
+
 type ChaosInstance struct {
+	ID        ChaosID
 	Namespace string            // Required
 	Selectors map[string]string // Required
 	Timeout   uint64            // Required
-	Duration  uint64            // Required
-	Count     int               // Optional
+	Count     int               // Required
 }
+
+type ChaosResult struct {
+	Status ChaosStatus
+	DeletedPods []string
+	Error string
+}
+
+type ChaosStatus string
+
+const (
+	ChaosFail ChaosStatus = "failed"
+	ChaosSuccess ChaosStatus = "success"
+)

--- a/internal/model/test.go
+++ b/internal/model/test.go
@@ -6,4 +6,5 @@ type Test struct {
 	ID   TestID
 	Name string
 	Jobs []Job
+	Chaos []ChaosInstance
 }

--- a/internal/model/testinstance.go
+++ b/internal/model/testinstance.go
@@ -9,6 +9,8 @@ type TestInstance struct {
 	Status    string
 	CreatedAt int64
 	Metrics   interface{} // TODO: decide how to store metrics long-term
+	ChaosResult map[ChaosID]ChaosResult
+	Error string
 }
 
 func (instance *TestInstance) IsTerminal() bool {

--- a/internal/tools/common.go
+++ b/internal/tools/common.go
@@ -1,0 +1,8 @@
+package tools
+
+func Max(a, b uint64) uint64 {
+    if a <= b {
+        return b
+    }
+    return a
+}

--- a/test/create.sh
+++ b/test/create.sh
@@ -57,24 +57,31 @@ make_dummy_test3() {
   output=$(curl "$base:30007/api/tests"\
         -H "Content-Type: application/json"\
         -d "{
-            \"Name\": \"Test3\",
+            \"Name\": \"Test5\",
             \"Jobs\": [
               {
                 \"Name\": \"alpha\",
-                \"Group\": \"test-worker\",
+                \"Group\": \"tests-worker\",
                 \"Priority\": 0,
                 \"Frequency\":  50,
 			          \"Duration\":   60,
 			          \"HTTPMethod\": \"GET\",
 			          \"HTTPUrl\":    \"http://dummy-service.default.svc.cluster.local:8080\"
               }
+            ],
+            \"Chaos\": [
+              {
+                \"Namespace\": \"default\",
+                \"Selectors\": {
+                  \"app\": \"dummy\"
+                },
+                \"Timeout\":  10,
+			          \"Count\":   1
+              }
             ]
           }")
   testid=$(echo $output | python3 -c "import sys, json; print(json.load(sys.stdin)['payload']['testid'])")
 }
 
-kubectl apply -f test/test.yaml
 
-make_dummy_test
-make_dummy_test2
 make_dummy_test3


### PR DESCRIPTION
This PR adds chaos simulation to the Test Template. You can specify a chaos simulation specifications optionally like a job. 

Example of test template with chaos simulation:

```
  curl "$base:30007/api/tests"\
        -H "Content-Type: application/json"\
      -d "{
          \"Name\": \"Test6\",
          \"Jobs\": [
            {
              \"Name\": \"alpha\",
              \"Group\": \"tests-worker\",
              \"Priority\": 0,
              \"Frequency\":  50,
	      \"Duration\":   60,
	      \"HTTPMethod\": \"GET\",
	      \"HTTPUrl\":    \"http://dummy-service.default.svc.cluster.local:8080\"
            }
          ],
          \"Chaos\": [
            {
              \"Namespace\": \"default\",
              \"Selectors\": {
                \"app\": \"dummy\"
              },
              \"Timeout\":  10,
	     \"Count\":   1
            }
          ]
        }"
``` 